### PR TITLE
fix(cleanup): unlink staged Unix descendant symlinks

### DIFF
--- a/src-tauri/crates/mangodisk-core/src/filesystem/permanent_delete.rs
+++ b/src-tauri/crates/mangodisk-core/src/filesystem/permanent_delete.rs
@@ -709,9 +709,10 @@ fn delete_via_staging(
 ///
 /// `remove_dir_all` has no cancellation hook, which is unacceptable for the
 /// large small-file trees most likely to be cancelled. The traversal uses
-/// `symlink_metadata` and the platform link-like policy; a link or Windows
-/// reparse point appearing after the earlier scan stops deletion and rolls
-/// back the remainder without following the target.
+/// `symlink_metadata` and the platform link-like policy. Unix symbolic-link
+/// entries are unlinked without following their targets. Other link-like
+/// entries, including Windows reparse points, stop deletion and roll back the
+/// remainder.
 fn remove_directory_tree_cancellable(
     root: &Path,
     is_cancelled: &(dyn Fn() -> bool + Sync),
@@ -738,6 +739,11 @@ fn remove_directory_tree_entry(
         ));
     }
     let metadata = fs::symlink_metadata(path)?;
+    #[cfg(unix)]
+    if metadata.file_type().is_symlink() {
+        fs::remove_file(path)?;
+        return Ok(());
+    }
     if current_platform().is_link_like(&metadata) {
         return Err(std::io::Error::other(
             "a link or reparse point appeared during directory tree deletion",
@@ -803,6 +809,11 @@ fn remove_directory_contents_entry(
         ));
     }
     let metadata = fs::symlink_metadata(path)?;
+    #[cfg(unix)]
+    if metadata.file_type().is_symlink() {
+        fs::remove_file(path)?;
+        return Ok(true);
+    }
     if current_platform().is_link_like(&metadata) {
         return Err(std::io::Error::other(
             "a link or reparse point appeared during directory contents deletion",
@@ -1505,6 +1516,79 @@ mod permanent_delete_tests {
         assert_eq!(outcome.released_bytes(), 11);
         assert_eq!(outcome.affected_item_count(), 2);
         assert!(!path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cancellable_directory_delete_unlinks_a_descendant_symlink_without_following_it() {
+        use std::os::unix::fs::symlink;
+
+        let sandbox = DeleteSandbox::new();
+        let path = sandbox.0.join("cancellable-directory-with-link");
+        let external = sandbox.0.join("external");
+        let protected_file = external.join("must-remain.bin");
+        fs::create_dir_all(&path).expect("create the cancellable fixture");
+        fs::create_dir_all(&external).expect("create the external fixture");
+        fs::write(&protected_file, b"protected").expect("write the protected fixture");
+        symlink(&external, path.join("external-link")).expect("create the descendant symlink");
+        let prepared = prepare_path_for_permanent_delete(&path)
+            .expect("the directory containing the symlink should be prepared");
+
+        let outcome =
+            delete_directory_tree_permanently_with_cancellation(prepared, 0, 0, &|| false)
+                .expect("the approved tree should be removed without following its symlink");
+
+        assert_eq!(outcome.released_bytes(), 0);
+        assert_eq!(outcome.affected_item_count(), 0);
+        assert!(
+            !path.exists(),
+            "the approved directory tree must be removed"
+        );
+        assert!(
+            protected_file.exists(),
+            "the external symlink target must remain untouched"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn directory_contents_delete_unlinks_a_descendant_symlink_without_following_it() {
+        use std::os::unix::fs::symlink;
+
+        let sandbox = DeleteSandbox::new();
+        let path = sandbox.0.join("directory-contents-with-link");
+        let retained_empty = path.join("retained-empty");
+        let external_link = path.join("external-link");
+        let external = sandbox.0.join("external");
+        let protected_file = external.join("must-remain.bin");
+        fs::create_dir_all(&retained_empty).expect("create the retained empty directory");
+        fs::create_dir_all(&external).expect("create the external fixture");
+        fs::write(&protected_file, b"protected").expect("write the protected fixture");
+        symlink(&external, &external_link).expect("create the descendant symlink");
+        let prepared = prepare_path_for_permanent_delete(&path)
+            .expect("the directory containing the symlink should be prepared");
+
+        let outcome = delete_directory_contents_permanently_with_cancellation(prepared, &|| false)
+            .expect("the approved contents should be removed without following their symlink");
+
+        assert_eq!(outcome.released_bytes(), 0);
+        assert_eq!(outcome.affected_item_count(), 0);
+        assert!(
+            path.exists(),
+            "the retained directory skeleton must be restored"
+        );
+        assert!(
+            retained_empty.exists(),
+            "the pre-existing empty directory must remain"
+        );
+        assert!(
+            fs::symlink_metadata(&external_link).is_err(),
+            "the descendant symlink entry must be removed"
+        );
+        assert!(
+            protected_file.exists(),
+            "the external symlink target must remain untouched"
+        );
     }
 
     #[test]

--- a/src-tauri/crates/mangodisk-core/src/filesystem/permanent_delete.rs
+++ b/src-tauri/crates/mangodisk-core/src/filesystem/permanent_delete.rs
@@ -62,11 +62,14 @@ pub(crate) struct PreparedPermanentDelete {
 ///
 /// Complete-root cleanup cannot treat an earlier scan summary as the actual
 /// result: tools may still write before atomic staging. Accumulating the live
-/// removal traversal keeps progress and history truthful.
+/// removal traversal keeps progress and history truthful. The internal mutation
+/// marker also records removals, such as links and directories, that intentionally
+/// do not contribute to regular-file accounting.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct PermanentDeleteOutcome {
     released_bytes: u64,
     affected_item_count: u64,
+    had_irreversible_mutation: bool,
 }
 
 impl PermanentDeleteOutcome {
@@ -83,6 +86,7 @@ impl PermanentDeleteOutcome {
         self.affected_item_count = self
             .affected_item_count
             .saturating_add(other.affected_item_count);
+        self.had_irreversible_mutation |= other.had_irreversible_mutation;
     }
 }
 
@@ -561,8 +565,7 @@ fn delete_via_staging(
             &staged_target,
             "the item was replaced before permanent deletion",
             Some(CoreErrorReason::ItemChanged),
-            0,
-            0,
+            PermanentDeleteOutcome::default(),
         )
         .map(|_| PermanentDeleteOutcome::default());
     }
@@ -570,6 +573,7 @@ fn delete_via_staging(
     let expected_outcome = PermanentDeleteOutcome {
         released_bytes: expected_bytes,
         affected_item_count: expected_item_count,
+        had_irreversible_mutation: false,
     };
     let removal_result = match removal {
         StagedRemoval::File => fs::remove_file(&staged_target)
@@ -683,11 +687,9 @@ fn delete_via_staging(
                         released_bytes: expected_bytes.saturating_sub(remaining.bytes),
                         affected_item_count: expected_item_count
                             .saturating_sub(remaining.item_count),
+                        had_irreversible_mutation: false,
                     })
             });
-            let released_bytes = verified_outcome.map_or(0, |outcome| outcome.released_bytes);
-            let affected_item_count =
-                verified_outcome.map_or(0, |outcome| outcome.affected_item_count);
             rollback_staged_target(
                 path,
                 &staging_root,
@@ -697,8 +699,7 @@ fn delete_via_staging(
                     delete_failure.error
                 ),
                 permanent_delete_io_reason(&delete_failure.error),
-                released_bytes,
-                affected_item_count,
+                verified_outcome.unwrap_or_default(),
             )
             .map(|_| PermanentDeleteOutcome::default())
         }
@@ -742,6 +743,7 @@ fn remove_directory_tree_entry(
     #[cfg(unix)]
     if metadata.file_type().is_symlink() {
         fs::remove_file(path)?;
+        outcome.had_irreversible_mutation = true;
         return Ok(());
     }
     if current_platform().is_link_like(&metadata) {
@@ -752,6 +754,7 @@ fn remove_directory_tree_entry(
     if metadata.is_file() {
         let bytes = metadata.len();
         fs::remove_file(path)?;
+        outcome.had_irreversible_mutation = true;
         outcome.released_bytes = outcome.released_bytes.saturating_add(bytes);
         outcome.affected_item_count = outcome.affected_item_count.saturating_add(1);
         return Ok(());
@@ -777,7 +780,9 @@ fn remove_directory_tree_entry(
             "directory tree deletion cancelled",
         ));
     }
-    fs::remove_dir(path)
+    fs::remove_dir(path)?;
+    outcome.had_irreversible_mutation = true;
+    Ok(())
 }
 
 fn remove_directory_contents_cancellable(
@@ -812,6 +817,7 @@ fn remove_directory_contents_entry(
     #[cfg(unix)]
     if metadata.file_type().is_symlink() {
         fs::remove_file(path)?;
+        outcome.had_irreversible_mutation = true;
         return Ok(true);
     }
     if current_platform().is_link_like(&metadata) {
@@ -822,6 +828,7 @@ fn remove_directory_contents_entry(
     if metadata.is_file() {
         let bytes = metadata.len();
         fs::remove_file(path)?;
+        outcome.had_irreversible_mutation = true;
         outcome.released_bytes = outcome.released_bytes.saturating_add(bytes);
         outcome.affected_item_count = outcome.affected_item_count.saturating_add(1);
         return Ok(true);
@@ -866,6 +873,7 @@ fn remove_directory_contents_entry(
     }
     if had_entry && all_removed {
         fs::remove_dir(path)?;
+        outcome.had_irreversible_mutation = true;
         return Ok(true);
     }
     Ok(false)
@@ -1001,13 +1009,18 @@ fn rollback_staged_target(
     staged_target: &Path,
     reason: &str,
     failure_reason: Option<CoreErrorReason>,
-    released_bytes: u64,
-    affected_item_count: u64,
+    outcome: PermanentDeleteOutcome,
 ) -> Result<(), PermanentDeleteError> {
+    let PermanentDeleteOutcome {
+        released_bytes,
+        affected_item_count,
+        had_irreversible_mutation,
+    } = outcome;
     match fs::rename(staged_target, original_path) {
         Ok(()) => {
             let _ = fs::remove_dir(staging_root);
-            let partially_deleted = released_bytes > 0 || affected_item_count > 0;
+            let partially_deleted =
+                released_bytes > 0 || affected_item_count > 0 || had_irreversible_mutation;
             let message = if partially_deleted {
                 format!(
                     "the item was partially deleted; remaining contents were restored: {reason}"
@@ -1552,6 +1565,45 @@ mod permanent_delete_tests {
 
     #[cfg(unix)]
     #[test]
+    fn cancellation_after_descendant_symlink_unlink_reports_partial_restored_deletion() {
+        use std::os::unix::fs::symlink;
+
+        let sandbox = DeleteSandbox::new();
+        let path = sandbox.0.join("cancelled-directory-with-link");
+        let external_link = path.join("external-link");
+        let external = sandbox.0.join("external");
+        let protected_file = external.join("must-remain.bin");
+        fs::create_dir_all(&path).expect("create the cancellation fixture");
+        fs::create_dir_all(&external).expect("create the external fixture");
+        fs::write(&protected_file, b"protected").expect("write the protected fixture");
+        symlink(&external, &external_link).expect("create the descendant symlink");
+        let prepared = prepare_path_for_permanent_delete(&path)
+            .expect("the directory containing the symlink should be prepared");
+        let checks = AtomicU64::new(0);
+
+        let error = delete_directory_tree_permanently_with_cancellation(prepared, 0, 0, &|| {
+            checks.fetch_add(1, Ordering::Relaxed) >= 3
+        })
+        .expect_err("cancellation should stop deletion after the symlink is unlinked");
+
+        assert!(error.is_partial());
+        assert!(error.remaining_was_restored());
+        assert_eq!(error.released_bytes(), 0);
+        assert_eq!(error.affected_item_count(), 0);
+        assert_eq!(checks.load(Ordering::Relaxed), 4);
+        assert!(path.exists(), "the remaining directory must be restored");
+        assert!(
+            fs::symlink_metadata(&external_link).is_err(),
+            "the unlinked descendant symlink must not be restored"
+        );
+        assert!(
+            protected_file.exists(),
+            "the external symlink target must remain untouched"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn directory_contents_delete_unlinks_a_descendant_symlink_without_following_it() {
         use std::os::unix::fs::symlink;
 
@@ -1800,8 +1852,11 @@ mod permanent_delete_tests {
             &staged_target,
             "simulated zero-byte partial deletion",
             None,
-            0,
-            1,
+            PermanentDeleteOutcome {
+                released_bytes: 0,
+                affected_item_count: 1,
+                had_irreversible_mutation: false,
+            },
         )
         .expect_err("a partial rollback should retain its structured outcome");
 


### PR DESCRIPTION
## Context

`5637f13` fixed the reported Unix FIFO hang by rejecting special files before deletion and using non-blocking, no-follow identity handles. This pull request builds on that change and addresses a separate cleanup failure exposed by the same investigation.

An approved directory cleanup currently rolls back when its staged tree contains an ordinary descendant symbolic link. This affects Xcode DerivedData in particular, because DerivedData commonly contains symlinks created by Xcode, Swift Package Manager, and versioned build products.

## Current behavior

The Xcode DerivedData rule owns the complete DerivedData root and uses the `deleteWholeRoot` execution path. The permanent-delete flow correctly validates the selected root, captures its physical identity, and moves it into a private same-volume staging directory before recursive removal.

The failure occurs during that final staged traversal:

1. The selected root passes the existing protected-path, link, metadata, and identity checks.
2. The root is moved into MangoDisk's private staging directory.
3. The cancellable traversal reads each descendant with `symlink_metadata`.
4. Any link-like descendant is treated as a fatal error.
5. MangoDisk restores the staged root and reports the cleanup as partial/items skipped.

This is appropriate for a symlink supplied as the top-level deletion target, where following or accepting the target would cross the user's approved boundary. It is unnecessarily restrictive for a symlink entry already contained by an approved, privately staged directory tree. The entry itself belongs to that tree and can be unlinked without traversing its target.

Leaving the link in place is not useful for whole-root cleanup: the containing directory cannot be removed while the entry remains, so the current behavior causes the entire otherwise-valid cleanup to roll back.

## Change

On Unix, both cancellable staged traversal modes now handle a descendant symbolic link by calling `fs::remove_file` on the link entry and returning success immediately:

- whole-tree removal used by `deleteWholeRoot`, including Xcode DerivedData;
- contents-only removal used by bulk cleanup of complete authorized directories.

The traversal continues to use `symlink_metadata`, so the link is identified without resolving its target. `remove_file` unlinks the Unix directory entry; it does not recurse into or delete the target, including when the target is a directory.

Symlink entries continue to contribute zero released bytes and zero affected regular-file items. If unlinking fails, the error still propagates through the existing staged-removal failure and rollback path.

## Safety boundaries preserved

- A symlink selected directly as the cleanup target remains rejected by the existing preflight validation.
- The containing directory must still pass the existing protected-path, canonical-path, metadata, and physical-identity checks.
- The existing private same-volume staging boundary remains unchanged.
- No symlink target is resolved, traversed, measured, or deleted.
- FIFOs, Unix sockets, and other unsupported special entries retain the behavior introduced by `5637f13`; this change does not duplicate or weaken that fix.
- Only actual Unix symbolic links receive the new behavior. Other link-like entries continue to fail closed.
- Windows reparse points and junctions retain the existing fail-closed behavior.
- Existing cancellation checks before and between directory entries remain unchanged.

## Why unlink instead of skip

Scanning may omit symlink targets from byte and file accounting, but execution still has to remove the symlink entry to complete deletion of the approved directory. Skipping the entry would leave the staged tree non-empty and prevent removal of the selected root. Unlinking the entry is therefore the minimal operation that satisfies the cleanup request without expanding its ownership boundary.

## Tests

Added Unix regression coverage for both staged traversal modes:

1. Whole-tree deletion with a descendant symlink to an external directory:
   - removes the approved directory tree;
   - leaves the external target and its file untouched;
   - does not add symlink bytes or a regular-file item to the outcome.
2. Contents-only deletion with a descendant symlink to an external directory:
   - removes the symlink entry;
   - leaves the external target untouched;
   - preserves the expected retained directory skeleton;
   - does not add symlink bytes or a regular-file item to the outcome.

These tests exercise the filesystem primitives used by Xcode DerivedData cleanup without adding Xcode-specific policy or fixtures.

## Validation

- `pnpm check`
  - 58 frontend test files passed
  - 278 frontend tests passed
  - formatting, lint, type checking, frontend build, Rust formatting, Clippy, and workspace checks passed
- `cargo test --manifest-path src-tauri/Cargo.toml -p mangodisk-core`
  - 372 passed
  - 0 failed
  - 61 ignored

Validation was run on macOS/Apple Silicon. The implementation is Unix-gated, and Windows reparse-point behavior is unchanged; Windows validation was not available locally for this follow-up and should be confirmed by CI.

## Scope

This pull request changes one Core filesystem file. It does not change the Xcode cleanup rule, the UI, cleanup selection policy, or the FIFO/special-file fix already merged in `5637f13`.