### PR TITLE
fix(storage): ignore duplicate large-file candidates

### DIFF
--- a/src-tauri/crates/mangodisk-core/src/storage/traversal.rs
+++ b/src-tauri/crates/mangodisk-core/src/storage/traversal.rs
@@ -915,6 +915,16 @@ impl<'a> LargeFileStreamValidation<'a> {
             // skipped count.
             return Ok(());
         }
+        if !sink.insert_large_file_candidate(
+            path.clone(),
+            IndexedFile {
+                bytes: usage.allocated_bytes,
+                logical_bytes: usage.logical_bytes,
+                modified_at_ms: modified_ms(&metadata),
+            },
+        ) {
+            return Ok(());
+        }
         self.progress.visit_file(
             traversal_stage(ScanPurpose::LargeFiles),
             &path,
@@ -926,14 +936,6 @@ impl<'a> LargeFileStreamValidation<'a> {
             .logical_bytes
             .saturating_add(usage.logical_bytes);
         self.aggregate.file_count += 1;
-        sink.push_large_file(
-            path,
-            IndexedFile {
-                bytes: usage.allocated_bytes,
-                logical_bytes: usage.logical_bytes,
-                modified_at_ms: modified_ms(&metadata),
-            },
-        )?;
         self.valid_count += 1;
         Ok(())
     }

--- a/src-tauri/crates/mangodisk-core/src/storage/traversal/index_sink.rs
+++ b/src-tauri/crates/mangodisk-core/src/storage/traversal/index_sink.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    path::PathBuf,
+};
 
 use mangodisk_platform::FilesystemChangeToken;
 
@@ -50,6 +53,20 @@ impl IndexRecordSink {
             return Err("the in-memory index received a duplicate large-file record".to_string());
         }
         Ok(())
+    }
+
+    /// Inserts a validated record from an advisory candidate source.
+    ///
+    /// Native filesystem indexes may repeat a path, so candidate ingestion is idempotent while
+    /// authoritative traversal streams keep their strict duplicate checks.
+    pub(super) fn insert_large_file_candidate(&mut self, path: PathBuf, file: IndexedFile) -> bool {
+        match self.files.entry(path) {
+            Entry::Vacant(entry) => {
+                entry.insert(file);
+                true
+            }
+            Entry::Occupied(_) => false,
+        }
     }
 
     pub(super) fn finish(self) -> Result<CompletedIndexSink, String> {

--- a/src-tauri/crates/mangodisk-core/src/storage/traversal_tests.rs
+++ b/src-tauri/crates/mangodisk-core/src/storage/traversal_tests.rs
@@ -126,6 +126,49 @@ fn native_large_file_candidate_below_physical_threshold_is_not_skipped() {
     assert_eq!(validation.aggregate.skipped_count, 0);
 }
 
+#[test]
+fn duplicate_native_large_file_candidate_is_idempotent() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!(
+        "MangoDisk-Duplicate-Large-Candidate-{}-{unique}",
+        std::process::id()
+    ));
+    let _sandbox_cleanup = DirectoryCleanup(root.clone());
+    fs::create_dir_all(&root).expect("create the duplicate candidate fixture");
+    let path = root.join("candidate.bin");
+    fs::write(&path, [1_u8, 2, 3, 4]).expect("write the duplicate candidate fixture");
+    let metadata = fs::metadata(&path).expect("read the duplicate candidate metadata");
+    let usage = current_platform().file_space_usage(&path, &metadata);
+    let progress = Arc::new(ProgressTracker::new(0, |_| {}, 0));
+    let cancelled = AtomicBool::new(false);
+    let mut validation = LargeFileStreamValidation::new(&root, 0, now_ms(), &progress, &cancelled)
+        .expect("prepare native large-file validation");
+    let mut sink = IndexRecordSink::memory(None);
+
+    validation
+        .consume(path.clone(), &mut sink)
+        .expect("accept the first native candidate");
+    validation
+        .consume(path, &mut sink)
+        .expect("ignore a duplicate native candidate");
+
+    assert_eq!(validation.valid_count, 1);
+    assert_eq!(validation.aggregate.bytes, usage.allocated_bytes);
+    assert_eq!(validation.aggregate.logical_bytes, usage.logical_bytes);
+    assert_eq!(validation.aggregate.file_count, 1);
+    assert_eq!(validation.aggregate.skipped_count, 0);
+    assert_eq!(
+        sink.finish()
+            .expect("finish the deduplicated candidate index")
+            .files
+            .len(),
+        1
+    );
+}
+
 #[cfg(target_os = "macos")]
 #[test]
 fn analysis_filesystem_boundary_keeps_firmlinks_and_rejects_mounts() {


### PR DESCRIPTION
## Summary

- make advisory native large-file candidate ingestion idempotent when a filesystem index repeats a path
- preserve strict duplicate rejection for authoritative traversal streams
- avoid double-counting progress, allocated/logical bytes, and file totals

## Problem

On macOS, a full-disk large-file scan can fail while consuming Spotlight results with:

```text
failed to consume the candidate stream: the in-memory index received a duplicate large-file record
```

Spotlight is an advisory candidate source and can repeat a path. A repeated, already-validated candidate should not abort the entire scan.

## Safety

Live scope, protection policy, filesystem, link-type, and size validation still runs before insertion. Only the advisory candidate insertion is idempotent; the existing strict duplicate checks for authoritative traversal/index records remain unchanged.

## Validation

- `pnpm check`
- `cargo test --manifest-path src-tauri/Cargo.toml -p mangodisk-core` (495 passed, 0 failed)
- deterministic regression test covering duplicate native candidates and aggregate accounting
- real macOS root-volume Spotlight fast-path scan completed successfully
- Windows was not run locally
